### PR TITLE
Add Verbose Argument for silencing TQDM

### DIFF
--- a/glcm_cupy/glcm_base.py
+++ b/glcm_cupy/glcm_base.py
@@ -43,6 +43,7 @@ class GLCMBase:
     max_partition_size: int = MAX_PARTITION_SIZE
     max_threads: int = MAX_THREADS
     normalized_features: bool = True
+    verbose: bool = True
 
     glcm_create_kernel: RawKernel = field(
         default=glcm_module.get_function('glcmCreateKernel'),
@@ -115,7 +116,8 @@ class GLCMBase:
         self.progress = tqdm(total=self.glcm_cells(im),
                              desc="GLCM Progress",
                              unit=" Cells",
-                             unit_scale=True)
+                             unit_scale=True,
+                             disable=not self.verbose)
 
         im = binner(im, self.bin_from, self.bin_to)
         return self._from_im(im)


### PR DESCRIPTION
Implement silencing through `verbose` arg

```py
# By default verbose
GLCM().run(ar_3d)

# Silence
GLCM(verbose=False).run(ar_3d)

# Explicit Verbose True
GLCM(verbose=True).run(ar_3d)
```

Closes #11