### PR TITLE
Fix Function verbose missing

### DIFF
--- a/glcm_cupy/cross/glcm_cross.py
+++ b/glcm_cupy/cross/glcm_cross.py
@@ -20,7 +20,8 @@ def glcm_cross(
     max_partition_size: int = MAX_PARTITION_SIZE,
     max_threads: int = MAX_THREADS,
     normalized_features: bool = True,
-    ix_combos: List[Tuple[int, int]] = None
+    verbose: bool = True,
+    ix_combos: List[Tuple[int, int]] | None = None
 ) -> np.ndarray:
     """ Runs the Cross GLCM algorithm
 
@@ -43,6 +44,9 @@ def glcm_cross(
         max_partition_size: Maximum number of windows to parse at once
         max_threads: Maximum threads for CUDA
         normalized_features: Whether to normalize features to [0, 1]
+        verbose: Whether to enable TQDM logging
+        ix_combos: Set of combinations to Cross with. If None, then all.
+            E.g. ix_combos = [(0, 1), (0, 2), ..., (2, 3), (3, 3)]
 
     Returns:
         GLCM Features
@@ -54,12 +58,18 @@ def glcm_cross(
         max_partition_size=max_partition_size,
         max_threads=max_threads,
         normalized_features=normalized_features,
-        ix_combos=ix_combos
+        ix_combos=ix_combos,
+        verbose=verbose
     ).run(im)
 
 
 @dataclass
 class GLCMCross(GLCMBase):
+    """
+    Args:
+        ix_combos: Set of combinations to Cross with. If None, then all.
+            E.g. ix_combos = [(0, 1), (0, 2), ..., (2, 3), (3, 3)]
+    """
     ix_combos: List[Tuple[int, int]] | None = None
 
     def ch_combos(self, im: np.ndarray) -> List[np.ndarray]:

--- a/glcm_cupy/glcm/glcm.py
+++ b/glcm_cupy/glcm/glcm.py
@@ -31,7 +31,8 @@ def glcm(
                                    Direction.SOUTH_WEST),
     max_partition_size: int = MAX_PARTITION_SIZE,
     max_threads: int = MAX_THREADS,
-    normalized_features: bool = True
+    normalized_features: bool = True,
+    verbose: bool = True
 ) -> np.ndarray:
     """
     Examples:
@@ -52,6 +53,7 @@ def glcm(
         max_partition_size: Maximum number of windows to parse at once
         max_threads: Maximum threads for CUDA
         normalized_features: Whether to normalize features to [0, 1]
+        verbose: Whether to enable TQDM logging
 
     Returns:
         GLCM Features
@@ -64,7 +66,8 @@ def glcm(
         max_threads=max_threads,
         normalized_features=normalized_features,
         step_size=step_size,
-        directions=directions
+        directions=directions,
+        verbose=verbose
     ).run(im)
 
 

--- a/glcm_cupy/glcm_base.py
+++ b/glcm_cupy/glcm_base.py
@@ -36,6 +36,7 @@ class GLCMBase:
         max_partition_size: Maximum number of windows to parse at once
         max_threads: Maximum number of threads to use per block
         normalize_features: Whether to normalize features to [0, 1]
+        verbose: Whether to enable TQDM logging
     """
     radius: int = 2
     bin_from: int = 256

--- a/tests/integration_tests/test_glcm.py
+++ b/tests/integration_tests/test_glcm.py
@@ -1,6 +1,9 @@
-import numpy as np
+import inspect
 
-from glcm_cupy import GLCM
+import numpy as np
+import pytest
+
+from glcm_cupy import GLCM, glcm
 
 
 def test_from_3dimage(ar_3d):
@@ -11,3 +14,16 @@ def test_from_3dimage(ar_3d):
 def test_from_2dimage(ar_2d):
     """ Tests with a 2D Image (1 Channel) """
     GLCM().run(ar_2d[..., np.newaxis])
+
+
+def test_output_match(ar_3d):
+    """ Tests if class & function outputs match """
+    assert GLCM().run(ar_3d) == pytest.approx(glcm(ar_3d))
+
+
+def test_signature_match():
+    """ Tests if class & function signatures match """
+    cls = dict(inspect.signature(GLCM).parameters)
+    fn = dict(inspect.signature(glcm).parameters)
+    del fn['im']
+    assert cls == fn

--- a/tests/integration_tests/test_glcm_cross.py
+++ b/tests/integration_tests/test_glcm_cross.py
@@ -1,7 +1,9 @@
+import inspect
+
 import numpy as np
 import pytest
 
-from glcm_cupy import GLCMCross
+from glcm_cupy import GLCMCross, glcm_cross
 
 
 def test_from_3dimage(ar_3d):
@@ -21,3 +23,16 @@ def test_from_2dimage(ar_2d):
     # This is not possible as we need > 1 channel to cross
     with pytest.raises(ValueError):
         GLCMCross().run(ar_2d[..., np.newaxis])
+
+
+def test_output_match(ar_3d):
+    """ Tests if class & function outputs match """
+    assert GLCMCross().run(ar_3d) == pytest.approx(glcm_cross(ar_3d))
+
+
+def test_signature_match():
+    """ Tests if class & function signatures match """
+    cls = dict(inspect.signature(GLCMCross).parameters)
+    fn = dict(inspect.signature(glcm_cross).parameters)
+    del fn['im']
+    assert cls == fn


### PR DESCRIPTION
Fix issue with function verbose missing 
https://github.com/Eve-ning/glcm-cupy/pull/14#issuecomment-1143089935

Additionally
- Added integration test to check fn & class
  - signature matching
  - output matching
- Fix minor type hinting issue with `GLCMCross(ix_combos=...)` not accepting `None`