### PR TITLE
Add support to CuPy as input and other changes related.

### DIFF
--- a/glcm_cupy/cross/glcm_cross.py
+++ b/glcm_cupy/cross/glcm_cross.py
@@ -2,18 +2,24 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from itertools import combinations
-from typing import Tuple, List
+from typing import Tuple, List, Union
 
 import cupy as cp
 import numpy as np
-from skimage.util import view_as_windows
+from skimage.util import view_as_windows as view_as_windows_np
+
+try:
+    from cucim.skimage.util.shape import view_as_windows as view_as_windows_cp
+    USE_CUCIM=True
+except:
+    USE_CUCIM=False
 
 from glcm_cupy.conf import *
 from glcm_cupy.glcm_base import GLCMBase
 
 
 def glcm_cross(
-    im: np.ndarray,
+    im: Union[np.ndarray, cp.ndarray],
     radius: int = 2,
     bin_from: int = 256,
     bin_to: int = 256,
@@ -22,7 +28,7 @@ def glcm_cross(
     normalized_features: bool = True,
     verbose: bool = True,
     ix_combos: List[Tuple[int, int]] | None = None
-) -> np.ndarray:
+) -> Union[np.ndarray, cp.ndarray]:
     """ Runs the Cross GLCM algorithm
 
     Notes:
@@ -72,25 +78,33 @@ class GLCMCross(GLCMBase):
     """
     ix_combos: List[Tuple[int, int]] | None = None
 
-    def ch_combos(self, im: np.ndarray) -> List[np.ndarray]:
+    def ch_combos(self, im: Union[np.ndarray,
+                                  cp.ndarray]) -> List[Union[np.ndarray,
+                                                             cp.ndarray]]:
         """ Get Image Channel Combinations """
         if self.ix_combos is None:
             # noinspection PyTypeChecker
             self.ix_combos = list(combinations(range(im.shape[-1]), 2))
         return [im[..., ix_combo] for ix_combo in self.ix_combos]
 
-    def glcm_cells(self, im: np.ndarray) -> float:
+    def glcm_cells(self, im: Union[np.ndarray, cp.ndarray]) -> float:
         """ Total number of GLCM cells to process """
         shape = self.glcm_shape(im[..., 0])
+
+        if isinstance(shape, cp.ndarray):
+            return cp.prod(shape) * len(self.ch_combos(im))
+
         return np.prod(shape) * len(self.ch_combos(im))
 
-    def glcm_shape(self, im_chn: np.ndarray) -> Tuple[int, int]:
+    def glcm_shape(self, im_chn: Union[np.ndarray, cp.ndarray]) -> Tuple[int, int]:
         """ Get per-channel shape after GLCM """
 
         return im_chn.shape[0] - 2 * self.radius, \
                im_chn.shape[1] - 2 * self.radius
 
-    def _from_im(self, im: np.ndarray) -> np.ndarray:
+    def _from_im(self, im: Union[np.ndarray,
+                                 cp.ndarray]) -> Union[np.ndarray,
+                                                       cp.ndarray]:
         """ Generates the GLCM from a multichannel image
 
         Args:
@@ -105,10 +119,17 @@ class GLCMCross(GLCMBase):
             raise ValueError(f"Cross GLCM needs >= 2 channels to combine")
         glcm_chs = [self._from_channel(ch_combo) for ch_combo in ch_combos]
 
+        if isinstance(glcm_chs, cp.ndarray):
+            return cp.stack(glcm_chs, axis=2)
+
         return np.stack(glcm_chs, axis=2)
 
-    def make_windows(self, im_chn: np.ndarray) -> List[Tuple[np.ndarray,
-                                                             np.ndarray]]:
+    def make_windows(self,
+                     im_chn: Union[np.ndarray,
+                                   cp.ndarray]) -> List[Tuple[Union[np.ndarray,
+                                                                    cp.ndarray],
+                                                              Union[np.ndarray,
+                                                                    cp.ndarray]]]:
         """ Convert a image dual channel np.ndarray, to GLCM IJ windows.
 
         Examples:
@@ -160,10 +181,22 @@ class GLCMCross(GLCMBase):
                 f"- 2 * radius {self.radius} + 1 <= 0 was not satisfied."
             )
 
-        i = cp.asarray(
-            view_as_windows(im_chn[..., 0], (self._diameter, self._diameter)))
-        j = cp.asarray(
-            view_as_windows(im_chn[..., 1], (self._diameter, self._diameter)))
+        if isinstance(im_chn, cp.ndarray):
+            if USE_CUCIM:
+                i = view_as_windows_cp(im_chn[..., 0], (self._diameter, self._diameter))
+                j = view_as_windows_cp(im_chn[..., 1], (self._diameter, self._diameter))
+            else:
+                # This is ugly, but there is nothing we could do if cuCIM is not
+                # installed. It should not be a hard requirement.
+                i = cp.asarray(
+                    view_as_windows_np(im_chn[..., 0].get(), (self._diameter, self._diameter)))
+                j = cp.asarray(
+                    view_as_windows_np(im_chn[..., 1].get(), (self._diameter, self._diameter)))
+        else:
+            i = cp.asarray(
+                view_as_windows_np(im_chn[..., 0], (self._diameter, self._diameter)))
+            j = cp.asarray(
+                view_as_windows_np(im_chn[..., 1], (self._diameter, self._diameter)))
 
         i = i.reshape((-1, *i.shape[-2:])) \
             .reshape((i.shape[0] * i.shape[1], -1))

--- a/glcm_cupy/cross/glcm_cross_py.py
+++ b/glcm_cupy/cross/glcm_cross_py.py
@@ -1,7 +1,8 @@
 import itertools
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
+import cupy as cp
 import numpy as np
 from skimage.util import view_as_windows
 from tqdm import tqdm
@@ -23,10 +24,14 @@ def glcm_cross_py_im(im: np.ndarray, bin_from: int, bin_to: int,
 class GLCMCrossPy(GLCMPyBase):
     ix_combos: List[Tuple[int, int]] = None
 
-    def glcm_chn(self, ar: np.ndarray):
-        ar = (ar / self.bin_from * self.bin_to).astype(np.uint8)
+    def glcm_chn(self, ar: Union[np.ndarray, cp.ndarray]):
+        # Convert to compatible types
+        if isinstance(ar, cp.ndarray):
+            ar = (ar / self.bin_from * self.bin_to).astype(cp.uint8)
+        else:
+            ar = (ar / self.bin_from * self.bin_to).astype(np.uint8)
 
-        def flat(ar_: np.ndarray):
+        def flat(ar_: Union[np.ndarray, cp.ndarray]):
             ar_ = ar_.reshape((-1, self.diameter, self.diameter))
             return ar_.reshape((ar_.shape[0], -1))
 
@@ -37,7 +42,11 @@ class GLCMCrossPy(GLCMPyBase):
             view_as_windows(ar[..., 1], (self.diameter, self.diameter))
         )
 
-        feature_ar = np.zeros((ar_w_i.shape[0], NO_OF_FEATURES))
+        if isinstance(ar, cp.ndarray):
+            feature_ar = cp.zeros((ar_w_i.shape[0], NO_OF_FEATURES))
+        else:
+            feature_ar = np.zeros((ar_w_i.shape[0], NO_OF_FEATURES))
+
         for e, (i, j) in tqdm(enumerate(zip(ar_w_i, ar_w_j)),
                               total=ar_w_i.shape[0]):
             feature_ar[e] = self.glcm_ij(i, j)
@@ -50,9 +59,16 @@ class GLCMCrossPy(GLCMPyBase):
 
         return normalize_features(feature_ar, self.bin_to)
 
-    def glcm_im(self, ar: np.ndarray):
+    def glcm_im(self, ar: Union[np.ndarray, cp.ndarray]):
         if self.ix_combos is None:
             self.ix_combos = list(itertools.combinations(range(ar.shape[-1]), 2))
+
+        if isinstance(ar, cp.ndarray):
+            return cp.stack(
+                [self.glcm_chn(ar[..., ix_combo]) for ix_combo in self.ix_combos],
+                axis=2
+            )
+
         return np.stack(
             [self.glcm_chn(ar[..., ix_combo]) for ix_combo in self.ix_combos],
             axis=2

--- a/glcm_cupy/glcm/glcm_py.py
+++ b/glcm_cupy/glcm/glcm_py.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
 
+from typing import Union
+
+import cupy as cp
 import numpy as np
 from skimage.util import view_as_windows
 from tqdm import tqdm
@@ -9,7 +12,7 @@ from glcm_cupy.glcm_py_base import GLCMPyBase
 from glcm_cupy.utils import normalize_features
 
 
-def glcm_py_im(ar: np.ndarray, bin_from: int, bin_to: int,
+def glcm_py_im(ar: Union[np.ndarray, cp.ndarray], bin_from: int, bin_to: int,
                radius: int = 2,
                step: int = 1):
     return GLCMPy(bin_from=bin_from,
@@ -18,7 +21,7 @@ def glcm_py_im(ar: np.ndarray, bin_from: int, bin_to: int,
                   step=step).glcm_im(ar)
 
 
-def glcm_py_chn(ar: np.ndarray,
+def glcm_py_chn(ar: Union[np.ndarray, cp.ndarray],
                 bin_from: int,
                 bin_to: int,
                 radius: int = 2,
@@ -29,8 +32,8 @@ def glcm_py_chn(ar: np.ndarray,
                   step=step).glcm_chn(ar)
 
 
-def glcm_py_ij(i: np.ndarray,
-               j: np.ndarray,
+def glcm_py_ij(i: Union[np.ndarray, cp.ndarray],
+               j: Union[np.ndarray, cp.ndarray],
                bin_from: int, bin_to: int):
     return GLCMPy(bin_from=bin_from,
                   bin_to=bin_to).glcm_ij(i, j)
@@ -40,12 +43,15 @@ def glcm_py_ij(i: np.ndarray,
 class GLCMPy(GLCMPyBase):
     step: int = 1
 
-    def glcm_chn(self, ar: np.ndarray):
+    def glcm_chn(self, ar: Union[np.ndarray, cp.ndarray]):
 
-        ar = (ar / self.bin_from * self.bin_to).astype(np.uint8)
+        if isinstance(ar, cp.ndarray):
+            ar = (ar / self.bin_from * self.bin_to).astype(cp.uint8)
+        else:
+            ar = (ar / self.bin_from * self.bin_to).astype(np.uint8)
         ar_w = view_as_windows(ar, (self.diameter, self.diameter))
 
-        def flat(ar: np.ndarray):
+        def flat(ar: Union[np.ndarray, cp.ndarray]):
             ar = ar.reshape((-1, self.diameter, self.diameter))
             return ar.reshape((ar.shape[0], -1))
 
@@ -55,7 +61,10 @@ class GLCMPy(GLCMPyBase):
         ar_w_j_se = flat(ar_w[self.step * 2:, self.step * 2:])
         ar_w_j_e = flat(ar_w[self.step:-self.step, self.step * 2:])
 
-        feature_ar = np.zeros((ar_w_i.shape[0], 4, NO_OF_FEATURES))
+        if isinstance(ar, cp.ndarray):
+            feature_ar = cp.zeros((ar_w_i.shape[0], 4, NO_OF_FEATURES))
+        else:
+            feature_ar = np.zeros((ar_w_i.shape[0], 4, NO_OF_FEATURES))
 
         for j_e, ar_w_j in enumerate(
             (ar_w_j_sw, ar_w_j_s, ar_w_j_se, ar_w_j_e)):
@@ -71,8 +80,11 @@ class GLCMPy(GLCMPyBase):
 
         return normalize_features(feature_ar, self.bin_to)
 
-    def glcm_im(self, ar: np.ndarray):
-
+    def glcm_im(self, ar: Union[np.ndarray, cp.ndarray]):
+        if isinstance(ar, cp.ndarray):
+            return cp.stack([self.glcm_chn(ar[..., ch])
+                             for ch
+                             in range(ar.shape[-1])], axis=2)
         return np.stack([self.glcm_chn(ar[..., ch])
                          for ch
                          in range(ar.shape[-1])], axis=2)

--- a/glcm_cupy/glcm_py_base.py
+++ b/glcm_cupy/glcm_py_base.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Union
 
+import cupy as cp
 import numpy as np
 
 
@@ -15,8 +16,8 @@ class GLCMPyBase:
         return self.radius * 2 + 1
 
     def glcm_ij(self,
-                i: np.ndarray,
-                j: np.ndarray) -> List[float]:
+                i: Union[np.ndarray, cp.ndarray],
+                j: Union[np.ndarray, cp.ndarray]) -> List[float]:
         """ Get GLCM features using Python
 
         Notes:
@@ -40,7 +41,10 @@ class GLCMPyBase:
         assert len(i_flat) == len(j_flat), \
             f"The shapes for i {i.shape} != j {j.shape}."
 
-        glcm = np.zeros((self.bin_to, self.bin_to), dtype=float)
+        if isinstance(i, cp.ndarray) and isinstance(j, cp.ndarray):
+            glcm = cp.zeros((self.bin_to, self.bin_to), dtype=float)
+        else:
+            glcm = np.zeros((self.bin_to, self.bin_to), dtype=float)
 
         # Populate the GLCM
         for i_, j_ in zip(i_flat, j_flat):

--- a/glcm_cupy/utils.py
+++ b/glcm_cupy/utils.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Tuple, Union
 
+import cupy as cp
 import numpy as np
 
 from glcm_cupy.conf import *
 
 
-def normalize_features(ar: np.ndarray, bin_to: int):
+def normalize_features(ar: Union[np.ndarray, cp.ndarray], bin_to: int):
     """ This scales the glcm features to [0, 1] """
     ar[..., CONTRAST] /= (bin_to - 1) ** 2
     ar[..., MEAN] /= (bin_to - 1)
@@ -39,16 +40,22 @@ def calc_grid_size(
     return b, b
 
 
-def binner(im: np.ndarray, bin_from: int, bin_to: int) -> np.ndarray:
+def binner(im: Union[np.ndarray,
+                     cp.ndarray],
+           bin_from: int, bin_to: int) -> Union[np.ndarray,
+                                                cp.ndarray]:
     """ Bins an image from a certain bin to another
 
     Args:
-        im: Image as np.ndarray
+        im: Image as np.ndarray or cp.ndarray
         bin_from: From the Bin of input image
         bin_to: To the Bin of output image
 
     Returns:
-        Binned Image as np.uint8
+        Binned Image as np.uint8 or cp.uint8
 
     """
+    # Convert to compatible types
+    if isinstance(im, cp.ndarray):
+        return (im.astype(cp.float32) / bin_from * bin_to).astype(cp.uint8)
     return (im.astype(np.float32) / bin_from * bin_to).astype(np.uint8)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,3 +1,4 @@
+import cupy as cp
 import numpy as np
 import pytest
 from PIL import Image
@@ -11,17 +12,27 @@ TEST_SIZE = 25
 def ar_3d():
     return np.random.randint(0, 256, (TEST_SIZE, TEST_SIZE, 3), dtype=np.uint8)
 
+@pytest.fixture()
+def ar_3d_cp():
+    return cp.random.randint(0, 256, (TEST_SIZE, TEST_SIZE, 3), dtype=cp.uint8)
 
 @pytest.fixture()
 def ar_img_3d():
     return Image.open(f"{ROOT_DIR}/data/image.jpg")
 
-
 @pytest.fixture()
 def ar_2d():
     return np.random.randint(0, 256, (TEST_SIZE, TEST_SIZE), dtype=np.uint8)
 
-
 @pytest.fixture()
 def ar_1d():
     return np.random.randint(0, 256, (TEST_SIZE,), dtype=np.uint8)
+
+@pytest.fixture()
+def ar_2d_cp():
+    return cp.random.randint(0, 256, (TEST_SIZE, TEST_SIZE), dtype=cp.uint8)
+
+
+@pytest.fixture()
+def ar_1d_cp():
+    return cp.random.randint(0, 256, (TEST_SIZE,), dtype=cp.uint8)

--- a/tests/integration_tests/test_glcm.py
+++ b/tests/integration_tests/test_glcm.py
@@ -21,6 +21,22 @@ def test_output_match(ar_3d):
     assert GLCM().run(ar_3d) == pytest.approx(glcm(ar_3d))
 
 
+def test_from_3dimage_cp(ar_3d_cp):
+    """ Tests using a 3D Image """
+    GLCM().run(ar_3d_cp)
+
+
+def test_from_2dimage_cp(ar_2d_cp):
+    """ Tests with a 2D Image (1 Channel) """
+    GLCM().run(ar_2d_cp[..., np.newaxis])
+
+
+def test_output_match_cp(ar_3d_cp):
+    """ Tests if class & function outputs match """
+    # XXX: pytest.approx does not support CuPy.
+    # It needs to get the NumPy array instead.
+    assert GLCM().run(ar_3d_cp).get() == pytest.approx(glcm(ar_3d_cp).get())
+
 def test_signature_match():
     """ Tests if class & function signatures match """
     cls = dict(inspect.signature(GLCM).parameters)

--- a/tests/integration_tests/test_glcm_cross.py
+++ b/tests/integration_tests/test_glcm_cross.py
@@ -30,6 +30,32 @@ def test_output_match(ar_3d):
     assert GLCMCross().run(ar_3d) == pytest.approx(glcm_cross(ar_3d))
 
 
+def test_from_3dimage_cp(ar_3d_cp):
+    """ Tests using a 3D Image """
+    GLCMCross().run(ar_3d_cp)
+
+
+def test_from_3dimage_ix_combo_cp(ar_3d_cp):
+    """ Tests using a 3D Image with selected ix_combos """
+    g = GLCMCross(ix_combos=[[0, 1], [1, 2]]).run(ar_3d_cp)
+    assert g.shape[2] == 2
+
+
+def test_from_2dimage_cp(ar_2d_cp):
+    """ Tests with a 2D Image (1 Channel) """
+
+    # This is not possible as we need > 1 channel to cross
+    with pytest.raises(ValueError):
+        GLCMCross().run(ar_2d_cp[..., np.newaxis])
+
+
+def test_output_match_cp(ar_3d_cp):
+    """ Tests if class & function outputs match """
+    # XXX: pytest.approx does not support CuPy.
+    # It needs to get the NumPy array instead.
+    assert GLCMCross().run(ar_3d_cp).get() == pytest.approx(glcm_cross(ar_3d_cp).get())
+
+
 def test_signature_match():
     """ Tests if class & function signatures match """
     cls = dict(inspect.signature(GLCMCross).parameters)

--- a/tests/integration_tests/test_glcm_cross_image.py
+++ b/tests/integration_tests/test_glcm_cross_image.py
@@ -1,3 +1,4 @@
+import cupy as cp
 import numpy as np
 from PIL import Image
 
@@ -8,4 +9,10 @@ from glcm_cupy.conf import ROOT_DIR
 def test_glcm_image():
     img = Image.open(f"{ROOT_DIR}/data/image.jpg")
     ar = np.asarray(img)[::5, ::5]
+    g = GLCM(bin_to=16).run(ar)
+
+
+def test_glcm_image_cupy():
+    img = Image.open(f"{ROOT_DIR}/data/image.jpg")
+    ar = cp.asarray(img)[::5, ::5]
     g = GLCM(bin_to=16).run(ar)

--- a/tests/unit_tests/util/glcm_py_skimage.py
+++ b/tests/unit_tests/util/glcm_py_skimage.py
@@ -1,18 +1,25 @@
 import numpy as np
-from skimage.feature import graycoprops, graycomatrix
+
+try:
+    # Try to import scikit-image 0.19+
+    from skimage.feature import greycoprops
+    from skimage.feature import greycomatrix
+except:
+    from skimage.feature import graycoprops as greycoprops
+    from skimage.feature import graycomatrix as greycomatrix
 
 
 def glcm_py_skimage(i, j):
     ar_ij = np.stack([i, j], axis=-1)
     ar_ji = np.stack([j, i], axis=-1)
-    glcm_ij = graycomatrix(ar_ij, (1,), (0,))
-    glcm_ji = graycomatrix(ar_ji, (1,), (0,))
+    glcm_ij = greycomatrix(ar_ij, (1,), (0,))
+    glcm_ji = greycomatrix(ar_ji, (1,), (0,))
     glcm = (glcm_ij + glcm_ji) / 2
 
-    contrast = float(graycoprops(glcm, 'contrast').squeeze())
-    homogeneity = float(graycoprops(glcm, 'homogeneity').squeeze())
-    asm = float(graycoprops(glcm, 'ASM').squeeze())
-    correlation = float(graycoprops(glcm, 'correlation').squeeze())
+    contrast = float(greycoprops(glcm, 'contrast').squeeze())
+    homogeneity = float(greycoprops(glcm, 'homogeneity').squeeze())
+    asm = float(greycoprops(glcm, 'ASM').squeeze())
+    correlation = float(greycoprops(glcm, 'correlation').squeeze())
 
     return dict(
         homogeneity=homogeneity,


### PR DESCRIPTION
This series just add support to CuPy input using Union structure. It also uses some functions dedicated to process image using a CPU only. For this all data can stay in GPU.

This patchset fixes issue #17.