### PR TITLE
Use Current results as assert snapshots

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -10,29 +10,38 @@ TEST_SIZE = 25
 
 @pytest.fixture()
 def ar_3d():
+    np.random.seed(8008)
     return np.random.randint(0, 256, (TEST_SIZE, TEST_SIZE, 3), dtype=np.uint8)
 
+
 @pytest.fixture()
-def ar_3d_cp():
-    return cp.random.randint(0, 256, (TEST_SIZE, TEST_SIZE, 3), dtype=cp.uint8)
+def ar_3d_cp(ar_3d):
+    return cp.asarray(ar_3d)
+
 
 @pytest.fixture()
 def ar_img_3d():
     return Image.open(f"{ROOT_DIR}/data/image.jpg")
 
+
 @pytest.fixture()
 def ar_2d():
+    np.random.seed(8008)
     return np.random.randint(0, 256, (TEST_SIZE, TEST_SIZE), dtype=np.uint8)
+
 
 @pytest.fixture()
 def ar_1d():
+    np.random.seed(8008)
     return np.random.randint(0, 256, (TEST_SIZE,), dtype=np.uint8)
 
+
 @pytest.fixture()
-def ar_2d_cp():
-    return cp.random.randint(0, 256, (TEST_SIZE, TEST_SIZE), dtype=cp.uint8)
+def ar_2d_cp(ar_2d):
+    return cp.asarray(ar_2d)
 
 
 @pytest.fixture()
 def ar_1d_cp():
+    np.random.seed(8008)
     return cp.random.randint(0, 256, (TEST_SIZE,), dtype=cp.uint8)

--- a/tests/integration_tests/test_glcm.py
+++ b/tests/integration_tests/test_glcm.py
@@ -8,34 +8,44 @@ from glcm_cupy import GLCM, glcm
 
 def test_from_3dimage(ar_3d):
     """ Tests using a 3D Image """
-    GLCM().run(ar_3d)
+    g = GLCM().run(ar_3d)
+    g_exp = np.load("expected/ar_3d_glcm.npy")
+    assert g == pytest.approx(g_exp, abs=1e-06)
 
 
 def test_from_2dimage(ar_2d):
     """ Tests with a 2D Image (1 Channel) """
-    GLCM().run(ar_2d[..., np.newaxis])
+    g = GLCM().run(ar_2d[..., np.newaxis])
+    g_exp = np.load("expected/ar_2d_glcm.npy")
+    assert g == pytest.approx(g_exp, abs=1e-06)
 
 
 def test_output_match(ar_3d):
     """ Tests if class & function outputs match """
-    assert GLCM().run(ar_3d) == pytest.approx(glcm(ar_3d))
+    assert GLCM().run(ar_3d) == pytest.approx(glcm(ar_3d), abs=1e-06)
 
 
 def test_from_3dimage_cp(ar_3d_cp):
     """ Tests using a 3D Image """
-    GLCM().run(ar_3d_cp)
+    g = GLCM().run(ar_3d_cp)
+    g_exp = np.load("expected/ar_3d_glcm.npy")
+    assert g.get() == pytest.approx(g_exp, abs=1e-06)
 
 
 def test_from_2dimage_cp(ar_2d_cp):
     """ Tests with a 2D Image (1 Channel) """
-    GLCM().run(ar_2d_cp[..., np.newaxis])
+    g = GLCM().run(ar_2d_cp[..., np.newaxis])
+    g_exp = np.load("expected/ar_2d_glcm.npy")
+    assert g.get() == pytest.approx(g_exp, abs=1e-06)
 
 
 def test_output_match_cp(ar_3d_cp):
     """ Tests if class & function outputs match """
     # XXX: pytest.approx does not support CuPy.
     # It needs to get the NumPy array instead.
-    assert GLCM().run(ar_3d_cp).get() == pytest.approx(glcm(ar_3d_cp).get())
+    assert GLCM().run(ar_3d_cp).get() == \
+           pytest.approx(glcm(ar_3d_cp).get(), abs=1e-06)
+
 
 def test_signature_match():
     """ Tests if class & function signatures match """

--- a/tests/integration_tests/test_glcm_cross.py
+++ b/tests/integration_tests/test_glcm_cross.py
@@ -8,12 +8,16 @@ from glcm_cupy import GLCMCross, glcm_cross
 
 def test_from_3dimage(ar_3d):
     """ Tests using a 3D Image """
-    GLCMCross().run(ar_3d)
+    g = GLCMCross().run(ar_3d)
+    g_exp = np.load("expected/ar_3d_glcm_cross.npy")
+    assert g == pytest.approx(g_exp, abs=1e-06)
 
 
 def test_from_3dimage_ix_combo(ar_3d):
     """ Tests using a 3D Image with selected ix_combos """
     g = GLCMCross(ix_combos=[[0, 1], [1, 2]]).run(ar_3d)
+    g_exp = np.load("expected/ar_3d_combo_glcm_cross.npy")
+    assert g == pytest.approx(g_exp, abs=1e-06)
     assert g.shape[2] == 2
 
 
@@ -27,17 +31,22 @@ def test_from_2dimage(ar_2d):
 
 def test_output_match(ar_3d):
     """ Tests if class & function outputs match """
-    assert GLCMCross().run(ar_3d) == pytest.approx(glcm_cross(ar_3d))
+    assert GLCMCross().run(ar_3d) == pytest.approx(glcm_cross(ar_3d),
+                                                   abs=1e-06)
 
 
 def test_from_3dimage_cp(ar_3d_cp):
     """ Tests using a 3D Image """
-    GLCMCross().run(ar_3d_cp)
+    g = GLCMCross().run(ar_3d_cp)
+    g_exp = np.load("expected/ar_3d_glcm_cross.npy")
+    assert g.get() == pytest.approx(g_exp, abs=1e-06)
 
 
 def test_from_3dimage_ix_combo_cp(ar_3d_cp):
     """ Tests using a 3D Image with selected ix_combos """
     g = GLCMCross(ix_combos=[[0, 1], [1, 2]]).run(ar_3d_cp)
+    g_exp = np.load("expected/ar_3d_combo_glcm_cross.npy")
+    assert g.get() == pytest.approx(g_exp, abs=1e-06)
     assert g.shape[2] == 2
 
 
@@ -53,7 +62,8 @@ def test_output_match_cp(ar_3d_cp):
     """ Tests if class & function outputs match """
     # XXX: pytest.approx does not support CuPy.
     # It needs to get the NumPy array instead.
-    assert GLCMCross().run(ar_3d_cp).get() == pytest.approx(glcm_cross(ar_3d_cp).get())
+    assert GLCMCross().run(ar_3d_cp).get() == \
+           pytest.approx(glcm_cross(ar_3d_cp).get(), abs=1e-06)
 
 
 def test_signature_match():

--- a/tests/integration_tests/test_glcm_cross_image.py
+++ b/tests/integration_tests/test_glcm_cross_image.py
@@ -1,5 +1,6 @@
 import cupy as cp
 import numpy as np
+import pytest
 from PIL import Image
 
 from glcm_cupy import GLCM
@@ -8,11 +9,15 @@ from glcm_cupy.conf import ROOT_DIR
 
 def test_glcm_image():
     img = Image.open(f"{ROOT_DIR}/data/image.jpg")
-    ar = np.asarray(img)[::5, ::5]
+    ar = np.asarray(img)[::20, ::20]
     g = GLCM(bin_to=16).run(ar)
+    g_exp = np.load("expected/glcm_image.npy")
+    assert g == pytest.approx(g_exp, abs=1e-06)
 
 
 def test_glcm_image_cupy():
     img = Image.open(f"{ROOT_DIR}/data/image.jpg")
-    ar = cp.asarray(img)[::5, ::5]
+    ar = cp.asarray(img)[::20, ::20]
     g = GLCM(bin_to=16).run(ar)
+    g_exp = np.load("expected/glcm_image.npy")
+    assert g.get() == pytest.approx(g_exp, abs=1e-06)

--- a/tests/integration_tests/test_glcm_image.py
+++ b/tests/integration_tests/test_glcm_image.py
@@ -1,4 +1,6 @@
+import cupy as cp
 import numpy as np
+import pytest
 from PIL import Image
 
 from glcm_cupy import GLCM, GLCMCross
@@ -7,5 +9,15 @@ from glcm_cupy.conf import ROOT_DIR
 
 def test_glcm_cross_image():
     img = Image.open(f"{ROOT_DIR}/data/image.jpg")
-    ar = np.asarray(img)[::5, ::5]
+    ar = np.asarray(img)[::20, ::20]
     g = GLCMCross(bin_to=16).run(ar)
+    g_exp = np.load("expected/glcm_cross_image.npy")
+    assert g == pytest.approx(g_exp, abs=1e-06)
+
+
+def test_glcm_cross_image_cupy():
+    img = Image.open(f"{ROOT_DIR}/data/image.jpg")
+    ar = cp.asarray(img)[::20, ::20]
+    g = GLCMCross(bin_to=16).run(ar)
+    g_exp = np.load("expected/glcm_cross_image.npy")
+    assert g.get() == pytest.approx(g_exp, abs=1e-06)


### PR DESCRIPTION
* We opt for a `pytest.approx` as the value fluctuates, thus `hash` is inconsistent