### PR TITLE
Reverts a migration to use view_as_windows_cp

### DIFF
--- a/glcm_cupy/cross/glcm_cross.py
+++ b/glcm_cupy/cross/glcm_cross.py
@@ -6,7 +6,7 @@ from itertools import combinations
 from math import prod
 from typing import Tuple, List, Set
 
-from glcm_cupy.utils import view_as_windows_cp
+from skimage.util import view_as_windows
 
 try:
     from cucim.skimage.util.shape import \
@@ -202,12 +202,14 @@ class GLCMCross(GLCMBase):
             j = view_as_windows_cucim(im_chn[..., 1],
                                       (self._diameter, self._diameter))
         else:
-            # This is ugly, but there is nothing we could do if cuCIM is
-            # not installed. It should not be a hard requirement.
-            i = view_as_windows_cp(im_chn[..., 0],
-                                   (self._diameter, self._diameter))
-            j = view_as_windows_cp(im_chn[..., 1].get(),
-                                   (self._diameter, self._diameter))
+            i = cp.array(view_as_windows(im_chn[..., 0].get(),
+                                         (self._diameter, self._diameter)))
+            # i = view_as_windows_cp(im_chn[..., 0],
+            #                        (self._diameter, self._diameter))
+            j = cp.array(view_as_windows(im_chn[..., 1].get(),
+                                         (self._diameter, self._diameter)))
+            # j = view_as_windows_cp(im_chn[..., 1],
+            #                        (self._diameter, self._diameter))
 
         i = i.reshape((-1, *i.shape[-2:])) \
             .reshape((i.shape[0] * i.shape[1], -1))

--- a/glcm_cupy/utils.py
+++ b/glcm_cupy/utils.py
@@ -63,8 +63,8 @@ def view_as_windows_cp(arr_in: cp.ndarray, window_shape, step=1):
         Adapted from ``skimage.util import view_as_windows``
     """
     ndim = arr_in.ndim
-    arr_shape = np.array(arr_in.shape)
-    window_shape = np.array(window_shape, dtype=arr_shape.dtype)
+    arr_shape = cp.array(arr_in.shape)
+    window_shape = cp.array(window_shape, dtype=arr_shape.dtype)
 
     if step < 1:
         raise ValueError("`step` must be >= 1")
@@ -78,15 +78,16 @@ def view_as_windows_cp(arr_in: cp.ndarray, window_shape, step=1):
 
     # -- build rolling window view
     slices = tuple(slice(None, None, st) for st in step)
-    window_strides = np.array(arr_in.strides)
+    window_strides = cp.array(arr_in.strides)
 
     indexing_strides = arr_in[slices].strides
 
-    win_indices_shape = (((np.array(arr_in.shape) - np.array(window_shape))
-                          // np.array(step)) + 1)
+    win_indices_shape = (((cp.array(arr_in.shape) - cp.array(window_shape))
+                          // cp.array(step)) + 1)
 
     new_shape = tuple(list(win_indices_shape) + list(window_shape))
     strides = tuple(list(indexing_strides) + list(window_strides))
 
-    arr_out = as_strided(arr_in, shape=new_shape, strides=strides)
+    arr_out = as_strided(arr_in, shape=tuple(map(int, new_shape)),
+                         strides=tuple(map(int, strides)))
     return arr_out


### PR DESCRIPTION
# Changes

- Reverts `view_as_window` in cross glcm to use previous `cp.array(skimage.view_as_windows(<CP.NDARRAY>.get()))`

For some reason, though the I/O are exactly the same, the results for cross glcm when using these 2 functions change.
It's likely something leaked out of the functions

Checks:
- I/O of the functions are exactly the same
- Tried to recast the array into CuPy, but assertion still fails