### PR TITLE
Skip border functionality

### DIFF
--- a/glcm_cupy/glcm_base.py
+++ b/glcm_cupy/glcm_base.py
@@ -306,7 +306,7 @@ class GLCMBase:
         self.ar_features[:] = 0
 
         no_of_windows = i.shape[0]
-        no_of_values = self._diameter ** 2
+        no_of_values = i.shape[1]
 
         if i.dtype != cp.uint8 or j.dtype != cp.uint8:
             raise ValueError(

--- a/tests/unit_tests/test_glcm.py
+++ b/tests/unit_tests/test_glcm.py
@@ -40,11 +40,15 @@ def test_glcm_normalize(ar):
     "radius",
     [1, 2, 4]
 )
-def test_glcm(size, bin_from, bin_to, radius):
+@pytest.mark.parametrize(
+    "skip_border",
+    [False, True]
+)
+def test_glcm(size, bin_from, bin_to, radius, skip_border):
     ar = np.random.randint(0, bin_from, [size, size, 1])
-    g = GLCM(radius=radius, bin_from=bin_from, bin_to=bin_to).run(ar)
-    g_fn = glcm(ar, radius=radius, bin_from=bin_from, bin_to=bin_to)
-    expected = glcm_py_im(ar, radius=radius, bin_from=bin_from, bin_to=bin_to)
+    g = GLCM(radius=radius, bin_from=bin_from, bin_to=bin_to, skip_border=skip_border).run(ar)
+    g_fn = glcm(ar, radius=radius, bin_from=bin_from, bin_to=bin_to, skip_border=skip_border)
+    expected = glcm_py_im(ar, radius=radius, bin_from=bin_from, bin_to=bin_to, skip_border=skip_border)
     assert g == pytest.approx(expected, abs=0.001)
     assert g_fn == pytest.approx(expected, abs=0.001)
 


### PR DESCRIPTION
- adapt GLCM class to compute GLCM with information only from the selected window, without neighboring information that is only present on the window pair, by skipping the border.

The image below exemplifies the process for each direction
![glcm_window](https://github.com/Eve-ning/glcm-cupy/assets/48109057/3a9dc0da-abd8-4623-acc3-4bc8326494c3)

Note that the default behavior is the same as it was previously (skip_border = False).